### PR TITLE
Adds support to load a quoteId create from the API

### DIFF
--- a/app/code/community/AltoLabs/Snappic/Model/Observer.php
+++ b/app/code/community/AltoLabs/Snappic/Model/Observer.php
@@ -8,6 +8,37 @@
  */
 class Altolabs_Snappic_Model_Observer
 {
+
+    /**
+     * Loads a quote id based in the soap session id
+     *
+     * @author Matias Nombarasco <matias.nombarasco@gmail.com>
+     * @param Varien_Event_Observer $observer
+     * @return self
+     */
+    public function createCustomerSession(Varien_Event_Observer $observer)
+    {
+        if ($token = Mage::app()->getRequest()->getParam('token')) {
+
+            //For now instead send the token we can send the quote ID to the url
+            $quoteId = Mage::app()->getRequest()->getParam('token');
+
+            //Can't use this because I couldn't make it save yet... I need to dig into the observer events for API
+            //$quoteId = Mage::getResourceModel('altolabs_snappic/session')->getQuoteIdByToken($token);
+            $quote = Mage::getModel('sales/quote')->load($quoteId);
+
+            /** @see Mage_Customer_Model_Customer */
+            //Creates the quote
+            $newQuote = Mage::getSingleton("checkout/session")->getQuote();
+
+            $newQuote->merge($quote);
+            // Also related the cart total after merge
+            $newQuote->collectTotals()->save();
+
+            return $this;
+        }
+    }
+
     /**
      * @param  Varien_Event_Observer $observer
      * @return self

--- a/app/code/community/AltoLabs/Snappic/Model/Resource/Session.php
+++ b/app/code/community/AltoLabs/Snappic/Model/Resource/Session.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class AltoLabs_Snappic_Model_Resource_Session
+ *
+ * @category Mage
+ * @package  AltoLabs_Snappic
+ * @author   AltoLabs <hi@altolabs.co>
+ */
+class AltoLabs_Snappic_Model_Resource_Session extends Mage_Core_Model_Resource_Db_Abstract
+{
+    /**
+     * Constructor method
+     */
+    public function _construct()
+    {
+        $this->_init('altolabs_snappic/session', 'id');
+    }
+
+    public function getQuoteIdByToken($token)
+    {
+        $adapter = $this->_getReadAdapter();
+
+        $select = $adapter->select()
+            ->from(
+                ['al' => $this->getTable('altolabs_snappic/session')],
+                [
+                    'quote_id'   => 'al.quote_id'
+                ]
+            )
+            ->where('soap_session_id = ?', $token)
+            ->limit(1);
+
+        $result = $this->_getReadAdapter()->fetchAll($select);
+        if (count($result) > 0) {
+            return $result[0]['quote_id'];
+        }
+
+        return [];
+    }
+}

--- a/app/code/community/AltoLabs/Snappic/Model/Session.php
+++ b/app/code/community/AltoLabs/Snappic/Model/Session.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class AltoLabs_Snappic_Model_Session
+ *
+ * @category Mage
+ * @package  AltoLabs_Snappic
+ * @author   AltoLabs <hi@altolabs.co>
+ */
+class AltoLabs_Snappic_Model_Session extends Mage_Core_Model_Abstract
+{
+    /**
+     * Constructor method
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('altolabs_snappic/session');
+    }
+}

--- a/app/code/community/AltoLabs/Snappic/data/snappic_setup/data-upgrade-0.0.1-0.0.2.php
+++ b/app/code/community/AltoLabs/Snappic/data/snappic_setup/data-upgrade-0.0.1-0.0.2.php
@@ -1,0 +1,26 @@
+<?php
+  /**
+ * Installs the Snappic persistent session tables
+ *
+ * This file is Copyright AltoLabs 2016.
+ *
+ * @category Mage
+ * @package  AltoLabs_Snappic
+ * @author   AltoLabs <hi@altolabs.co>
+ */
+
+$installer = $this;
+$installer->startSetup();
+
+$installer->run("
+    DROP TABLE IF EXISTS {$installer->getTable('altolabs_snappic/session')};
+
+    CREATE TABLE {$installer->getTable('altolabs_snappic/session')} (
+    id int(11) unsigned zerofill NOT NULL AUTO_INCREMENT,
+    soap_session_id varchar(250) DEFAULT NULL,
+    quote_id varchar(250) DEFAULT NULL,
+    PRIMARY KEY (id)
+    ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+  ");
+
+$installer->endSetup();

--- a/app/code/community/AltoLabs/Snappic/etc/config.xml
+++ b/app/code/community/AltoLabs/Snappic/etc/config.xml
@@ -11,7 +11,7 @@
 <config>
     <modules>
         <AltoLabs_Snappic>
-            <version>0.0.1</version>
+            <version>0.0.2</version>
         </AltoLabs_Snappic>
     </modules>
 
@@ -19,7 +19,16 @@
         <models>
             <altolabs_snappic>
                 <class>AltoLabs_Snappic_Model</class>
+                <resourceModel>snappic_resource</resourceModel>
             </altolabs_snappic>
+            <snappic_resource>
+                <class>AltoLabs_Snappic_Model_Resource</class>
+                <entities>
+                    <session>
+                        <table>altolabs_snappic_session</table>
+                    </session>
+                </entities>
+            </snappic_resource>
         </models>
 
         <helpers>
@@ -47,6 +56,14 @@
                 </observers>
             </sales_order_place_after>
         </events>
+        <controller_action_predispatch>
+            <observers>
+                <altolabs_snappic_observer_quote_before>
+                    <class>altolabs_snappic/observer</class>
+                    <method>createCustomerSession</method>
+                </altolabs_snappic_observer_quote_before>
+            </observers>
+        </controller_action_predispatch>
     </global>
 
     <frontend>


### PR DESCRIPTION
This is meant to be used using the Magento vanilla SOAP methods without any extra modifications. 

My way to run the test was to emulate the SOAP calls the FE should do

```
<?php

$curl = curl_init('http://dockerized-magento.local/api.php/?type=v2_soap&wsdl=1');
curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);

$wsdl_string = curl_exec($curl);

file_put_contents('temp.xml', $wsdl_string);

//Assuming the FE already has the store id...
$storeId = 1;
try {
    $proxy = new SoapClient('temp.xml');

    //Need to login to obtain a session_id
    $sessionId = $proxy->login('user', 'password');

    //Need to create a cart in order to be able to add to the cart
    $quoteId = $proxy->shoppingCartCreate($sessionId, $storeId);

    //Add product to the cart assuming the following product_id and sku exits in your local installation
    $result = $proxy->shoppingCartProductAdd(
        $sessionId, $quoteId, [[
                             'product_id'        => '2',
                             'sku'               => 'simple_product',
                             'qty'               => '2',
                             'options'           => null,
                             'bundle_option'     => null,
                             'bundle_option_qty' => null,
                             'links'             => null
                         ]]
    );

    //now you can hit the url with the quoteId and it will loaded it
    echo "http://dockerized-magento.local/?token=" . $quoteId;

} catch (Exception $e) {
    print '<pre>';
    var_dump($e->getMessage());
    print '</pre>';
}
```

Where user and password are valid API credentials with right permissions to:
- Shopping Cart > Products > Add products to shopping cart
- Shopping Cart > Create shopping cart
