### PR TITLE
Use minified SOAP for production

### DIFF
--- a/app/code/community/AltoLabs/Snappic/controllers/IndexController.php
+++ b/app/code/community/AltoLabs/Snappic/controllers/IndexController.php
@@ -32,7 +32,7 @@ class AltoLabs_Snappic_IndexController extends Mage_Core_Controller_Front_Action
             webcomponents_url: '$storeAssetsHost/bower_components/webcomponentsjs/webcomponents-lite.min.js',
             styles_url: '$storeAssetsHost/styles/main.css',
             bundle_url: '$storeAssetsHost/elements/elements.vulcanized.html',
-            soapjs_url: '$storeAssetsHost/scripts/soap.js',
+            soapjs_url: '$storeAssetsHost/scripts/soap.min.js',
             xml2json_url: '$storeAssetsHost/scripts/xml2json.min.js',
             enable_ig_error_detect: true,
             enable_infinite_scroll: true,


### PR DESCRIPTION
@hickscorp hey dude, I know client-side SOAP is deprecated with your new awesome endpoints - but I suppose it is ok to leave the `IndexController` as it is. The FE shouldn't be affected from a performance view point.

For completeness, I'm creating this PR to point to the minified SOAP anyway.

p/s: FWIW, you can force FE to use client-side SOAP by using http://mage.snappic.io/shopinsta?enable_magento_json_endpoints=false
